### PR TITLE
MLO-71: fix the host url issue

### DIFF
--- a/run_gradio.py
+++ b/run_gradio.py
@@ -15,7 +15,7 @@ def main(args):
         model_half=args.model_half
     )
     interface.queue()
-    interface.launch(share=args.share, auth=(args.username, args.password) if args.username is not None else None)
+    interface.launch(server_name="0.0.0.0", server_port=7860, share=args.share, auth=(args.username, args.password) if args.username is not None else None)
 
 if __name__ == "__main__":
     import argparse


### PR DESCRIPTION
By default gradio was starting the server on `127.0.0.1` we need it to start it on `0.0.0.0` for it to work externally

### Screenshots
![Screenshot 2025-01-07 at 16 55 44](https://github.com/user-attachments/assets/125d3a93-d89c-498b-afdc-8d71f3103323)
